### PR TITLE
a11y: WAVE audit changes

### DIFF
--- a/src/app/cmalt/page.tsx
+++ b/src/app/cmalt/page.tsx
@@ -97,9 +97,7 @@ export default async function CmaltHomePage() {
             />
 
             <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-4 pt-20 md:grid-cols-[16rem_1fr]">
-                <CmaltSidebar />
-
-                <div className="max-w-3xl">
+                <div className="order-2 max-w-3xl">
                     <main
                         id="main"
                         className="prose prose-slate dark:prose-invert max-w-none"
@@ -202,6 +200,7 @@ export default async function CmaltHomePage() {
                         />
                     )}
                 </div>
+                <CmaltSidebar />
             </div>
 
             {/* Footer CTA for contact and clarifications */}

--- a/src/components/Layouts/CmaltLayout.tsx
+++ b/src/components/Layouts/CmaltLayout.tsx
@@ -83,9 +83,7 @@ export default async function CmaltLayout({
 
             {/* Two-column grid: Sidebar + main content */}
             <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-4 pt-20 md:grid-cols-[16rem_1fr]">
-                <CmaltSidebar />
-
-                <div className="max-w-3xl">
+                <div className="order-2 max-w-3xl">
                     <main
                         id="main"
                         className="prose prose-slate dark:prose-invert max-w-none"
@@ -103,6 +101,8 @@ export default async function CmaltLayout({
                         />
                     )}
                 </div>
+
+                <CmaltSidebar />
             </div>
 
             {/* Footer CTA for contact and clarifications */}

--- a/src/components/Layouts/ProjectLayout.tsx
+++ b/src/components/Layouts/ProjectLayout.tsx
@@ -56,8 +56,7 @@ export default async function ProjectLayout({
                 topics={topics}
             />
             <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-4 pt-20 md:grid-cols-[16rem_1fr]">
-                <ProjectsSidebar rootSelector="#main" />
-                <div className="max-w-3xl">
+                <div className="order-2 max-w-3xl">
                     <EntryCoverImage {...thumbnail} />
                     <main
                         id="main"
@@ -77,6 +76,7 @@ export default async function ProjectLayout({
                         />
                     )}
                 </div>
+                <ProjectsSidebar rootSelector="#main" />
             </div>
             <ContactCta
                 title="Want a deeper dive?"

--- a/src/components/about/BioSidebar.tsx
+++ b/src/components/about/BioSidebar.tsx
@@ -14,9 +14,9 @@ const { LocationIcon } = icons;
 export default function BioSidebar() {
     return (
         <aside aria-labelledby="glance2" className="md:sticky md:top-24">
-            <h3 id="glance2" className="mb-4 text-lg font-semibold">
+            <h2 id="glance2" className="mb-4 text-lg font-semibold">
                 At a glance
-            </h3>
+            </h2>
             <ul className="items-start gap-3 divide-y divide-slate-200 overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-sm  dark:divide-slate-800 dark:border-slate-800 dark:bg-slate-900">
                 {bioSidebarItems.map(({ icon: Icon, title, description }) => (
                     <li key={title} className="flex gap-3 p-4">

--- a/src/components/cmalt/CmaltSidebar.server.tsx
+++ b/src/components/cmalt/CmaltSidebar.server.tsx
@@ -20,7 +20,7 @@ export default async function CmaltSidebar() {
     return (
         <aside
             aria-label="CMALT navigation"
-            className="sticky top-[4.5rem] hidden max-h-[calc(100vh-6rem)] overflow-auto rounded-2xl border border-slate-200 bg-white p-5 shadow-sm md:block dark:border-slate-800 dark:bg-slate-900"
+            className="sticky top-[4.5rem] order-1 hidden max-h-[calc(100vh-6rem)] overflow-auto rounded-2xl border border-slate-200 bg-white p-5 shadow-sm md:block dark:border-slate-800 dark:bg-slate-900"
         >
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
                 CMALT Portfolio

--- a/src/components/projects/ProjectsSidebar.tsx
+++ b/src/components/projects/ProjectsSidebar.tsx
@@ -103,10 +103,10 @@ export default function ProjectsSidebar({
     }
 
     return (
-        <aside className="sticky top-[4.5rem] hidden max-h-[calc(100vh-6rem)] overflow-auto rounded-2xl border border-slate-200 bg-white p-5 text-sm shadow-sm md:block dark:border-slate-800 dark:bg-slate-900">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+        <aside className="sticky top-[4.5rem] order-1 hidden max-h-[calc(100vh-6rem)] overflow-auto rounded-2xl border border-slate-200 bg-white p-5 text-sm shadow-sm md:block dark:border-slate-800 dark:bg-slate-900">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
                 On this page
-            </p>
+            </h3>
             <nav className="toc space-y-1" aria-label="On this page">
                 {headings.map((h) => {
                     const isActive = activeId === h.id;
@@ -116,7 +116,9 @@ export default function ProjectsSidebar({
                             href={`#${h.id}`}
                             className={[
                                 "block rounded px-2 py-1 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800",
-                                isActive ? "text-primary  dark:bg-primary dark:text-white" : "text-slate-700",
+                                isActive
+                                    ? "text-primary  dark:bg-primary dark:text-white"
+                                    : "text-slate-700",
                             ].join(" ")}
                         >
                             {h.text}

--- a/src/components/ui/AuthorCard.tsx
+++ b/src/components/ui/AuthorCard.tsx
@@ -36,7 +36,7 @@ export default function AuthorCard() {
             <div className="flex flex-col items-center gap-4 rounded-2xl border border-slate-200 bg-white p-5 text-center shadow-sm sm:flex-row sm:text-left dark:border-slate-800 dark:bg-slate-900">
                 <Image
                     src={profileImage}
-                    alt="Karl Horning"
+                    alt=""
                     className="h-32 w-32 rounded-2xl border border-slate-200 bg-primary object-cover dark:border-slate-800"
                     height={64}
                     width={64}

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -53,9 +53,12 @@ export default function Hero({ title, leadParagraph, tagline }: HeroProps) {
             <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-8 px-4 py-20 md:flex-row lg:py-24">
                 <div className="order-2 md:order-1">
                     {tagline && (
-                        <p className="text-sm font-semibold uppercase text-primary">
+                        <span
+                            className="text-sm font-semibold uppercase text-primary dark:text-pink-500"
+                            aria-hidden="true"
+                        >
                             {tagline}
-                        </p>
+                        </span>
                     )}
                     <h1 className="mt-2 text-pretty text-4xl font-extrabold tracking-tight sm:text-5xl">
                         {title}

--- a/src/components/ui/PageIntroSplit.tsx
+++ b/src/components/ui/PageIntroSplit.tsx
@@ -122,7 +122,10 @@ export default function PageIntroSplit({
     const Copy = (
         <div className="order-2 text-center md:order-1 md:text-left">
             {tagline && (
-                <p className="flex items-center justify-center gap-2 text-sm font-semibold uppercase tracking-wide text-primary md:justify-start">
+                <span
+                    className="flex items-center justify-center gap-2 text-sm font-semibold uppercase tracking-wide text-primary md:justify-start dark:text-pink-500"
+                    aria-hidden="true"
+                >
                     {/* Small decorative icon appears only on mobile */}
                     <span
                         className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-primary/10 text-primary md:hidden"
@@ -133,7 +136,7 @@ export default function PageIntroSplit({
                         </span>
                     </span>
                     {tagline}
-                </p>
+                </span>
             )}
 
             <h1 className="mt-2 text-pretty text-4xl font-extrabold tracking-tight sm:text-5xl">


### PR DESCRIPTION
- Reorder main content and sidebars
- Set taglines as decoration
- Change paragraphs before lists to titles
- Remove alt from decorative author image