### PR TITLE
chore: streamline accessibility resources post

### DIFF
--- a/public/data/posts.json
+++ b/public/data/posts.json
@@ -1,7 +1,7 @@
 [
     {
         "title": "Web Accessibility Resources and Tools: Guidelines, Checklists, and Testing Solutions",
-        "description": "A curated guide to web accessibility resources, tools, and checklists — including WCAG guidelines, free testing tools, and practical articles for developers and designers.",
+        "description": "A reference list of web accessibility tools, guidelines, and articles — with starred items for quick starting points.",
         "date": "2025-10-22T20:10:00Z",
         "readingTime": 7,
         "slug": "web-accessibility-resources-and-tools",

--- a/src/app/blog/web-accessibility-resources-and-tools/meta.ts
+++ b/src/app/blog/web-accessibility-resources-and-tools/meta.ts
@@ -4,7 +4,7 @@ import "server-only";
 export const meta = {
     title: "Web Accessibility Resources and Tools: Guidelines, Checklists, and Testing Solutions",
     description:
-        "A curated guide to web accessibility resources, tools, and checklists — including WCAG guidelines, free testing tools, and practical articles for developers and designers.",
+        "A reference list of web accessibility tools, guidelines, and articles — with starred items for quick starting points.",
     date: "2025-10-22T20:10:00Z",
     readingTime: 7,
     slug: "web-accessibility-resources-and-tools",

--- a/src/app/blog/web-accessibility-resources-and-tools/page.tsx
+++ b/src/app/blog/web-accessibility-resources-and-tools/page.tsx
@@ -15,43 +15,13 @@ export default function Page() {
     return (
         <BlogLayout {...meta}>
             <p>
-                Creating websites that everyone can use isn&apos;t just a legal
-                or ethical responsibility — it&apos;s good design. Accessibility
-                ensures that everyone, regardless of ability, can interact with
-                digital content effectively. Whether you&apos;re auditing an
-                existing site or building something new, the following resources
-                will help you understand best practices, run accessibility
-                tests, and stay aligned with current standards such as WCAG 2.2.
+                A reference list of web accessibility tools, guidelines, and
+                articles. Starred items (⭐️) are good starting points if
+                you&apos;re new to accessibility or just want to focus on the
+                essentials.
             </p>
 
-            <p>
-                ⭐️ <strong>Pro tip:</strong> Look out for the items marked with
-                a star — they&apos;re great starting points if you&apos;re new
-                to accessibility or just want to focus on the essentials.
-            </p>
-
-            <h2>How to Use This Guide</h2>
-            <p>
-                I&apos;ve organised these resources into categories so you can
-                find what&apos;s relevant quickly. From community-led sites and
-                official guidelines to testing tools and contrast checkers, this
-                guide is both a learning resource and a practical reference for
-                developers, designers, and content creators aiming to build more
-                inclusive digital experiences.
-            </p>
-
-            <p>
-                I&apos;ve been collecting accessibility resources for over seven
-                years, and this post will continue to evolve as I discover new
-                tools and updates.
-            </p>
-
-            <h2>Accessibility Checklist</h2>
-            <p>
-                Start by familiarising yourself with accessibility standards and
-                checklists. These will help you evaluate your content and
-                identify common issues early before they become bigger problems.
-            </p>
+            <h2>Checklist</h2>
 
             <FigureWithCaption
                 src={"/img/blog/accessibility-resources/wcag-screenshot.avif"}
@@ -68,23 +38,20 @@ export default function Page() {
                     >
                         The Web Content Accessibility Guidelines (WCAG)
                     </a>
-                    : A detailed checklist based on WCAG, providing guidelines
-                    for creating accessible web content.
+                    : A detailed checklist based on WCAG 2.2, providing
+                    guidelines for creating accessible web content.
                 </li>
             </ul>
 
-            <h2>Accessibility Guidance</h2>
+            <h2>Guidance</h2>
 
-            <h3>Community and Official Resources</h3>
-
-            <h4>Community-Driven Resources</h4>
+            <h3>Community resources</h3>
 
             <FigureWithCaption
                 src={"/img/blog/accessibility-resources/a11y-screenshot.avif"}
                 alt=""
                 caption="The A11Y Project is a community hub for practical accessibility resources."
             />
-
             <ul>
                 <li>
                     ⭐️{" "}
@@ -108,16 +75,36 @@ export default function Page() {
                     </a>
                     : Practical tips and advice for web accessibility.
                 </li>
+                <li>
+                    <a
+                        href="https://inclusivedesignprinciples.info/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Inclusive Design Principles
+                    </a>
+                    : A concise set of principles for designing inclusively.
+                </li>
+                <li>
+                    <a
+                        href="https://accessibility.blog.gov.uk/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        The Accessibility Blog (GOV.UK)
+                    </a>
+                    : Case studies and guidance from the UK Government Digital
+                    Service.
+                </li>
             </ul>
 
-            <h4>Official Documentation</h4>
+            <h3>Official documentation</h3>
 
             <FigureWithCaption
                 src={"/img/blog/accessibility-resources/mdn-screenshot.avif"}
                 alt=""
                 caption="Mozilla's resource hub for developers tackling accessibility."
             />
-
             <ul>
                 <li>
                     ⭐️{" "}
@@ -126,9 +113,20 @@ export default function Page() {
                         target="_blank"
                         rel="noopener noreferrer"
                     >
-                        MD Accessibility
+                        MDN Accessibility
                     </a>
-                    : Mozilla Developer&apos;s guide to web accessibility.
+                    : Mozilla&apos;s guide to web accessibility.
+                </li>
+                <li>
+                    <a
+                        href="https://www.w3.org/WAI/standards-guidelines/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        W3C Accessibility Standards Overview
+                    </a>
+                    : An overview of W3C standards including WCAG, ARIA, and
+                    ATAG.
                 </li>
                 <li>
                     <a
@@ -138,8 +136,8 @@ export default function Page() {
                     >
                         Understanding WCAG 2.0
                     </a>
-                    : The official documentation explaining the Web Content
-                    Accessibility Guidelines.
+                    : The official documentation explaining each WCAG
+                    guideline in detail.
                 </li>
                 <li>
                     <a
@@ -152,15 +150,63 @@ export default function Page() {
                     : Step-by-step tutorials from the Web Accessibility
                     Initiative (WAI).
                 </li>
+                <li>
+                    <a
+                        href="https://www.w3.org/TR/html-aria/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        ARIA in HTML
+                    </a>
+                    : The official W3C guide to using ARIA roles and labels
+                    effectively.
+                </li>
             </ul>
 
-            <h3>Articles and Tutorials</h3>
-            <p>
-                These give background, techniques, and practical tips to bring
-                accessibility into your workflow.
-            </p>
+            <h3>Keyboard accessibility</h3>
 
-            <h4>Introduction to Accessibility</h4>
+            <FigureWithCaption
+                src={"/img/blog/accessibility-resources/webaim-screenshot.avif"}
+                alt=""
+                caption="WebAIM's guide explaining how to make sites navigable by keyboard."
+            />
+            <ul>
+                <li>
+                    ⭐️{" "}
+                    <a
+                        href="https://webaim.org/techniques/keyboard/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Keyboard Accessibility
+                    </a>
+                    : A detailed walkthrough for making sites keyboard-friendly.
+                </li>
+                <li>
+                    <a
+                        href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Keyboard (MDN)
+                    </a>
+                    : Mozilla&apos;s reference for keyboard accessibility
+                    standards.
+                </li>
+                <li>
+                    <a
+                        href="https://support.mozilla.org/en-US/kb/accessibility-features-firefox-make-firefox-and-we"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Accessibility features in Firefox
+                    </a>
+                    : How Firefox supports users who rely on accessibility
+                    features.
+                </li>
+            </ul>
+
+            <h3>Articles and case studies</h3>
             <ul>
                 <li>
                     <a
@@ -184,74 +230,6 @@ export default function Page() {
                     : Mozilla&apos;s guidance on solving common accessibility
                     issues.
                 </li>
-            </ul>
-
-            <h4>Keyboard Accessibility</h4>
-
-            <FigureWithCaption
-                src={"/img/blog/accessibility-resources/webaim-screenshot.avif"}
-                alt=""
-                caption="WebAIM's guide explaining how to make sites navigable by keyboard."
-            />
-
-            <ul>
-                <li>
-                    ⭐️{" "}
-                    <a
-                        href="https://webaim.org/techniques/keyboard/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Keyboard Accessibility
-                    </a>
-                    : A detailed walkthrough for making sites keyboard-friendly.
-                </li>
-                <li>
-                    <a
-                        href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Keyboard (MDN)
-                    </a>
-                    : Mozilla&apos;s advice on keyboard accessibility standards.
-                </li>
-            </ul>
-
-            <h4>ARIA and Screen Reader Guidance</h4>
-            <ul>
-                <li>
-                    <a
-                        href="https://support.mozilla.org/en-US/kb/accessibility-features-firefox-make-firefox-and-we"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Accessibility features in Firefox
-                    </a>
-                    : How Firefox supports accessibility features
-                </li>
-                <li>
-                    <a
-                        href="https://www.w3.org/TR/html-aria/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        ARIA in HTML
-                    </a>
-                    : The official W3 guide to using ARIA roles and labels
-                    effectively
-                </li>
-            </ul>
-
-            <h4>Testing Standards & Case Studies</h4>
-
-            <FigureWithCaption
-                src={"/img/blog/accessibility-resources/ssa508-screenshot.avif"}
-                alt=""
-                caption="SSA's Section 508 Test Method is an official framework for evaluating accessibility."
-            />
-
-            <ul>
                 <li>
                     ⭐️{" "}
                     <a
@@ -261,13 +239,9 @@ export default function Page() {
                     >
                         SSA 508 Test Method
                     </a>
-                    : The Social Security Administration&apos;s accessibility
-                    testing approach.
+                    : The Social Security Administration&apos;s structured
+                    approach to accessibility testing.
                 </li>
-            </ul>
-
-            <h4>Insights and Case Studies</h4>
-            <ul>
                 <li>
                     <a
                         href="https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/"
@@ -277,7 +251,8 @@ export default function Page() {
                         What we found when we tested tools on the world&apos;s
                         least-accessible webpage
                     </a>
-                    : GOV.UK&apos;s insights from testing accessibility tools.
+                    : GOV.UK&apos;s honest comparison of automated testing
+                    tools.
                 </li>
                 <li>
                     <a
@@ -287,20 +262,19 @@ export default function Page() {
                     >
                         This guide is unreadable
                     </a>
-                    : A cautionary tale about poor accessibility practices.
+                    : A useful example of what poor accessibility looks like in
+                    practice.
                 </li>
             </ul>
 
-            <h2>Free Tools</h2>
+            <h2>Testing tools</h2>
             <p>
-                Automated and manual testing tools can save time and highlight
-                accessibility barriers. While no tool can replace human testing,
-                these are some of the most reliable free options available.
+                No tool catches everything — automated tools typically find
+                around 30-40% of accessibility issues. Use them alongside
+                manual testing and keyboard navigation checks.
             </p>
 
-            <h3>Browser Tools</h3>
-
-            <h4>Testing and Evaluation Tools</h4>
+            <h3>Browser extensions</h3>
 
             <FigureWithCaption
                 src={
@@ -309,7 +283,6 @@ export default function Page() {
                 alt=""
                 caption="Google Lighthouse offers audits for accessibility and site performance."
             />
-
             <ul>
                 <li>
                     ⭐️{" "}
@@ -320,7 +293,8 @@ export default function Page() {
                     >
                         Lighthouse
                     </a>
-                    : A free, open-source audit tool from Google.
+                    : Built into Chrome DevTools. Audits accessibility,
+                    performance, SEO, and best practices.
                 </li>
                 <li>
                     <a
@@ -328,13 +302,13 @@ export default function Page() {
                         target="_blank"
                         rel="noopener noreferrer"
                     >
-                        Axe
+                        axe DevTools
                     </a>
-                    : One of the most popular accessibility testing libraries.
+                    : One of the most widely used accessibility testing
+                    libraries, available as a browser extension and via{" "}
+                    <code>@axe-core/playwright</code> for automated testing.
                 </li>
             </ul>
-
-            <h4>Browser Extensions</h4>
 
             <FigureWithCaption
                 src={
@@ -343,7 +317,6 @@ export default function Page() {
                 alt=""
                 caption="Microsoft's Accessibility Insights tool for detecting and fixing accessibility issues."
             />
-
             <ul>
                 <li>
                     ⭐️{" "}
@@ -355,7 +328,7 @@ export default function Page() {
                         Accessibility Insights
                     </a>
                     : Microsoft&apos;s extension for finding and fixing
-                    accessibility problems.
+                    accessibility issues, including a guided FastPass workflow.
                 </li>
                 <li>
                     ARIA DevTools{" "}
@@ -394,36 +367,12 @@ export default function Page() {
                     >
                         (Chrome)
                     </a>
-                    : WebAIM&apos;s easy-to-use browser extension for visual
-                    accessibility checks.
+                    : WebAIM&apos;s browser extension for visual accessibility
+                    checks.
                 </li>
             </ul>
 
-            <h3>Standalone & Web-Based Tools</h3>
-            <ul>
-                <li>
-                    <a
-                        href="https://pa11y.org/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Pa11y
-                    </a>
-                    : Command-line tool for automated accessibility testing.
-                </li>
-                <li>
-                    <a
-                        href="https://asqatasun.org/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Asqatasun
-                    </a>
-                    : Open-source tool for automated accessibility testing.
-                </li>
-            </ul>
-
-            <h3>Contrast and Visual Tests</h3>
+            <h3>Contrast checkers</h3>
 
             <FigureWithCaption
                 src={
@@ -432,7 +381,6 @@ export default function Page() {
                 alt=""
                 caption="WebAIM's Contrast Checker makes colour contrast testing quick and simple."
             />
-
             <ul>
                 <li>
                     ⭐️{" "}
@@ -443,8 +391,8 @@ export default function Page() {
                     >
                         Contrast Checker
                     </a>
-                    : Quickly see if text and background colours meet
-                    accessibility standards.
+                    : WebAIM&apos;s tool for checking text and background
+                    colour contrast ratios against WCAG thresholds.
                 </li>
                 <li>
                     <a
@@ -454,18 +402,17 @@ export default function Page() {
                     >
                         Colour Contrast Accessibility Validator
                     </a>
-                    : An alternative for contrast checks.
+                    : Scans an entire page for contrast issues.
                 </li>
             </ul>
 
-            <h3>Visual Accessibility Testing</h3>
+            <h3>Visual testing and standalone tools</h3>
 
             <FigureWithCaption
                 src={"/img/blog/accessibility-resources/wave-screenshot.avif"}
                 alt=""
                 caption="WebAIM's WAVE tool highlights accessibility issues visually on the page."
             />
-
             <ul>
                 <li>
                     ⭐️{" "}
@@ -476,8 +423,19 @@ export default function Page() {
                     >
                         WAVE
                     </a>
-                    : One of the most widely used visual accessibility
-                    evaluation tools.
+                    : Overlays visual indicators on the page to show
+                    accessibility issues in context.
+                </li>
+                <li>
+                    <a
+                        href="https://pa11y.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Pa11y
+                    </a>
+                    : Command-line tool for automated accessibility testing.
+                    Useful in CI pipelines.
                 </li>
                 <li>
                     <a
@@ -487,7 +445,7 @@ export default function Page() {
                     >
                         HTML_CodeSniffer
                     </a>
-                    : Detects code-level issues.
+                    : Detects code-level accessibility issues.
                 </li>
                 <li>
                     <a
@@ -497,69 +455,22 @@ export default function Page() {
                     >
                         tota11y
                     </a>
-                    : A JavaScript library that visualises accessibility errors
-                    directly on your webpage.
+                    : A JavaScript bookmarklet that visualises accessibility
+                    errors directly on the page.
+                </li>
+                <li>
+                    <a
+                        href="https://asqatasun.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Asqatasun
+                    </a>
+                    : Open-source tool for automated accessibility auditing.
                 </li>
             </ul>
-
-            <h2>Final Thoughts</h2>
-
-            <p>
-                Getting started with accessibility can feel overwhelming at
-                first, but even small, consistent steps make a difference. The
-                key is to keep learning, testing, and listening to the people
-                who will actually use your digital content. Accessibility
-                isn&apos;t about ticking boxes — it&apos;s about creating better
-                experiences for everyone, regardless of ability.
-            </p>
-
-            <p>
-                Don&apos;t be discouraged by the technical challenges; it&apos;s
-                a journey of ongoing improvement. Use the tools and resources
-                above as your allies, and don&apos;t hesitate to seek feedback
-                from users or fellow developers. The more inclusive your
-                approach, the more your work can truly make a positive impact.
-            </p>
-
-            <p>
-                In the end, accessibility benefits us all. When we design with
-                everyone in mind, we create websites, apps, and digital spaces
-                that are more usable, welcoming, and effective. Keep at it —
-                every bit of effort counts.
-            </p>
 
             <p>— Karl</p>
-
-            <h2>Further Reading</h2>
-            <ul>
-                <li>
-                    <a
-                        href="https://www.w3.org/WAI/standards-guidelines/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        W3C Accessibility Standards Overview
-                    </a>
-                </li>
-                <li>
-                    <a
-                        href="https://inclusivedesignprinciples.info/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Inclusive Design Principles
-                    </a>
-                </li>
-                <li>
-                    <a
-                        href="https://accessibility.blog.gov.uk/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        The Accessibility Blog (GOV.UK)
-                    </a>
-                </li>
-            </ul>
         </BlogLayout>
     );
 }


### PR DESCRIPTION
- remove explanatory text
- streamline number of headers and density
- use sentence case for titles
- clarify link descriptions